### PR TITLE
Use nodejs12.x

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -11,7 +11,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.handler
-      Runtime: nodejs8.10
+      Runtime: nodejs12.x
       Description: "CloudFront website redirects for an S3 origin. Available through the Serverless Application Repository."
       Environment:
         Variables:


### PR DESCRIPTION
Was getting this error when trying to deploy:

>```
> The runtime parameter of nodejs8.10 is no longer supported for creating or updating AWS Lambda functions.
> We recommend you use the new runtime (nodejs12.x) while creating or updating functions.
>(Service: AWSLambdaInternal; Status Code: 400; Error Code: InvalidParameterValueException;
>```

The reason for the error is that AWS no longer supports `nodejs8.10`, see:

https://aws.amazon.com/blogs/compute/node-js-12-x-runtime-now-available-in-aws-lambda/
https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html